### PR TITLE
embassy / fix panic with arena size of 128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ embassy-executor = { version = "0.6.1", features = [
     "integrated-timers",
     "arch-spin",
     "executor-thread",
-    "task-arena-size-128", # or better use nightly, but fails on recent Rust versions
+    "task-arena-size-192", # or better use nightly, but fails on recent Rust versions
 ] }
 embassy-time = { version = "0.3.0" }
 {%- endif %}


### PR DESCRIPTION
When generating a project with embassy on the ch32V003 (just the 'basic' blink as-generated by `cargo generate`), the project builds but panics. Increasing arena size over 128 fixes the issue.

Building with stable `rustc 1.83.0 (90b35a623 2024-11-26)`